### PR TITLE
Fix T polyomino incorrectly being an S type

### DIFF
--- a/src/js/Polyomino.js
+++ b/src/js/Polyomino.js
@@ -78,7 +78,7 @@ export default class Polyomino {
 export const tetrominos = {
     'I': new Polyomino([[0, 0], [0, 1], [0, 2], [0, 3]]),
     'O': new Polyomino([[0, 0], [0, 1], [1, 1], [1, 0]]),
-    'T': new Polyomino([[0, 1], [1, 1], [1, 0], [2, 0]]),
+    'T': new Polyomino([[0, 1], [1, 1], [1, 0], [2, 1]]),
     'J': new Polyomino([[0, 0], [1, 0], [1, 1], [1, 2]]),
     'L': new Polyomino([[0, 2], [0, 1], [0, 0], [1, 0]]),
     'S': new Polyomino([[0, 0], [1, 0], [1, 1], [2, 1]]),


### PR DESCRIPTION
Quick fix for T tetromino for the 'click to add standard tetromino' section.