### PR TITLE
Replace polyfill.io URL

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
         <title>Polyomino Solver</title>
         <meta name="description" content="Solve general tetromino and polyomino tiling problems">
         <!-- I guess I'll support browsers besides latest-Chrome -->
-        <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js"></script>
         <script src="https://unpkg.com/@webcomponents/webcomponentsjs@^2/webcomponents-bundle.js"></script>
         <link rel="stylesheet" href="styles.css">
         <link rel="icon" type="image/png" href="favicon.png">


### PR DESCRIPTION
[polyfill.io was used to host malicious code in a supply chain attack](https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet/), and it has been taken down. This replaces polyfill.io with Cloudflare's polyfill.